### PR TITLE
[Auto] 自动忽略移除 - httpsslprowebcomdownloadWin64OpenSSL-3_0_8msi

### DIFF
--- a/auto_script/check/checker/Program.cs
+++ b/auto_script/check/checker/Program.cs
@@ -167,7 +167,6 @@ namespace checker
                 "https://www.betterbird.eu/", // 过于复杂
                 "https://github.com/ClassicOldSong/Apollo/releases/download/v0.2.9-alpha.3/Apollo.exe", "https://dtapp-pub.dingtalk.com/dingtalk-desktop/win_installer/Release/DingTalk_v7.6.15.91110808.exe", "https://github.com/DockerBeam/DockerBeam/releases/download/v0.1.0/DockerBeam_windows_x86.exe", // WIP
                 "https://github.com/paintdotnet/release/", // 更新时移除
-                "https://slproweb.com/download/Win64OpenSSL-3_0_8.msi", // 不是安装程序
                 "https://cdn.krisp.ai", "https://www.huaweicloud.com/", "https://mirrors.kodi.tv", "https://scache.vzw.com", // 假404
             ];
             return excludedDomains.Any(domain => url.Contains(domain));


### PR DESCRIPTION
### 此 PR 由 @DuckDuckStudio 的自动化创建🤖，用于向检查代码**移除**忽略字段 `https://slproweb.com/download/Win64OpenSSL-3_0_8.msi`
理由: 优化安装程序 url 判断规则/逻辑后不再需要