### PR TITLE
[Auto] 自动忽略移除 - httpssf1-cdn-tosdouyinstaticcomobjmicroappfrontendidepackageobjdeveloperide12056684win32

### DIFF
--- a/auto_script/check/checker/Program.cs
+++ b/auto_script/check/checker/Program.cs
@@ -168,7 +168,7 @@ namespace checker
                 "https://github.com/paintdotnet/release/", // 更新时移除
                 "https://cdn.krisp.ai", "https://www.huaweicloud.com/", "https://mirrors.kodi.tv", "https://scache.vzw.com", "https://acessos.fiorilli.com.br/api/instalacao/webextension.exe", "https://www.magicdesktop.com/get/kiosk?src=winget", // 假404
                 "https://www.deezer.com/", // 无法验证
-                "https://sf1-cdn-tos.douyinstatic.com/obj/microapp/frontend/ide/package/obj/developer/ide/12056684/win32/", "https://sf1-cdn-tos.douyinstatic.com/obj/microapp/frontend/ide/package/obj/developer/ide/11797316/win32/", "https://b2.zczc.men/file/dos-electron-assets/release/", // 不完整的url
+                "https://sf1-cdn-tos.douyinstatic.com/obj/microapp/frontend/ide/package/obj/developer/ide/11797316/win32/", "https://b2.zczc.men/file/dos-electron-assets/release/", // 不完整的url
                 "https://sourceforge.net/", // 假403
             ];
             return excludedDomains.Any(domain => url.Contains(domain));


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `https://sf1-cdn-tos.douyinstatic.com/obj/microapp/frontend/ide/package/obj/developer/ide/12056684/win32/`
理由: 重复