### PR TITLE
[Auto] 自动忽略移除 - httpsdljisutodocomjisutodo_setup_3002exehttpsgiteecomdevcppctermreleasesdownloadv400CTerm-40exe

### DIFF
--- a/auto_script/check/checker/Program.cs
+++ b/auto_script/check/checker/Program.cs
@@ -181,7 +181,6 @@ namespace checker
                 "https://www.deezer.com/", // 无法验证
                 "https://b2.zczc.men/file/dos-electron-assets/release/", "https://sf1-cdn-tos.douyinstatic.com/", "https://download.hellofont.cn/Client/Release/channels_backup/4.1.1/official/", "https://alistatic.lanhuapp.com/Axure/", // 不完整的url
                 "https://sourceforge.net/", // 假403
-                "https://dl.jisutodo.com/jisutodo_setup_3.0.0.2.exe", "https://gitee.com/devcpp/cterm/releases/download/v4.0.0/CTerm-4.0.exe", // WIP
             ];
             return excludedDomains.Any(domain => url.Contains(domain));
         }


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `https://dl.jisutodo.com/jisutodo_setup_3.0.0.2.exe", "https://gitee.com/devcpp/cterm/releases/download/v4.0.0/CTerm-4.0.exe`
理由: 相关修改已合并