### PR TITLE
[Auto] 自动忽略移除 - httpsgithubcomwinsidersssi-buildsreleasesdownload3225044321systeminformer-3225044321-canary-setupexe

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -337,7 +337,7 @@ namespace checker
                 "https://issuepcdn.baidupcs.com/", "https://lf-luna-release.qishui.com/obj/luna-release/", "https://down.360safe.com/cse/", // 超时
                 "https://www.argyllcms.com/", // 服务器拒绝冲泡咖啡
                 "https://www.elcomsoft.com/", "https://pbank.bankcomm.cn/personbank/download/SecEditCFCAforBoCom.exe", // SSL错误
-                "https://github.com/winsiderss/si-builds/releases/download/3.2.25044.321/systeminformer-3.2.25044.321-canary-setup.exe", "https://download.eset.com/com/eset/tools/installers/av_remover/latest/avremover_arm64_enu.exe", // WIP
+                "https://download.eset.com/com/eset/tools/installers/av_remover/latest/avremover_arm64_enu.exe", // WIP
             ];
             return excludedDomains.Any(domain => url.Contains(domain));
         }


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `https://github.com/winsiderss/si-builds/releases/download/3.2.25044.321/systeminformer-3.2.25044.321-canary-setup.exe`
理由: 修改已合并 - https://github.com/microsoft/winget-pkgs/pull/250664