### PR TITLE
[Auto] 自动忽略移除 - httpsxmcl-release-msazureedgenetreleaseshttpsgithubcomkiwixkiwix-js-windowsreleasesdownloadv262-WikivoyageWikivoyage-by-Kiwix-Setup-262-Eexe

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -337,7 +337,7 @@ namespace checker
                 "https://issuepcdn.baidupcs.com/", "https://lf-luna-release.qishui.com/obj/luna-release/", "https://down.360safe.com/cse/", // 超时
                 "https://www.argyllcms.com/", // 服务器拒绝冲泡咖啡
                 "https://www.elcomsoft.com/", "https://pbank.bankcomm.cn/personbank/download/SecEditCFCAforBoCom.exe", // SSL错误
-                "https://download.eset.com/com/eset/tools/installers/av_remover/latest/avremover_arm64_enu.exe", "https://xmcl-release-ms.azureedge.net/releases/", "https://github.com/kiwix/kiwix-js-windows/releases/download/v2.6.2-Wikivoyage/Wikivoyage-by-Kiwix-Setup-2.6.2-E.exe", "http://www.heaventools.com/files/11hFgnI0s/FlexHex_editor_setup.exe", // WIP
+                "https://download.eset.com/com/eset/tools/installers/av_remover/latest/avremover_arm64_enu.exe", "http://www.heaventools.com/files/11hFgnI0s/FlexHex_editor_setup.exe", // WIP
                 "https://aurorabuilder.com/downloads/Aurora%20Setup.zip", // 假400
             ];
             return excludedDomains.Any(domain => url.Contains(domain));


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `https://xmcl-release-ms.azureedge.net/releases/", "https://github.com/kiwix/kiwix-js-windows/releases/download/v2.6.2-Wikivoyage/Wikivoyage-by-Kiwix-Setup-2.6.2-E.exe`
理由: 修改已合并