### PR TITLE
feat: 检测不安全的 URL (HTTP)，并尝试可能的安全 URL (HTTPS)

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -203,6 +203,29 @@ namespace checker
                             else
                             // 除了上面的 400 - 500
                             {
+                                // 如果这个 URL 是 HTTP 而不是 HTTPS 的
+                                if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    // 尝试使用 HTTPS 访问
+                                    string httpsUrl = url.Replace("http://", "https://", StringComparison.OrdinalIgnoreCase);
+                                    try
+                                    {
+                                        HttpResponseMessage httpsResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, httpsUrl));
+                                        // 如果可以访问 (<400)
+                                        if ((int)httpsResponse.StatusCode < 400)
+                                        {
+                                            Console.WriteLine($"\n[Warning] {filePath} 中的 {url} 不安全 (HTTP)，请使用安全 URL {httpsUrl} (HTTPS) 替代。");
+                                            if (failureLevel == "warning")
+                                            {
+                                                return false;
+                                            }
+                                        }
+                                    }
+                                    catch
+                                    {
+                                        // 忽略异常
+                                    }
+                                }
                                 Console.Write("*");
                             }
                         }

--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -52,7 +52,7 @@ namespace checker
             }
         }
 
-        internal static readonly string[] installerType = [".exe", ".zip", ".msi", ".msix", ".appx", "&download"];
+        internal static readonly string[] installerType = [".exe", ".zip", ".msi", ".msix", ".appx", "download"];
         // &download 为 sourceforge 和类似网站的下载链接
 
         static async Task<bool> CheckUrlsInYamlFiles(string folderPath, string failureLevel)


### PR DESCRIPTION
## 修改
- feat: 检测不安全的 URL (HTTP)，并尝试可能的安全 URL (HTTPS)
  - 如果 URL 请求成功
  - 判断此 URL 是否为不安全的 (HTTP) URL
    - 如果是
      - 将 URL 的 `http://` 替换为 `https://` 并赋值给 `httpsUrl`
      - 尝试请求新的安全 (HTTPS) URL
        - 如果请求成功 (响应状态码 <400)
          - 显示 ⚠警告⚠ 提示，并在失败等级为 `warning` 时使检查失败
        - 如果请求失败
          - 使用空 `catch` 块忽略异常
    - 如果不是 (HTTPS)
      - 不进行任何处理
- fix: 以 `&download` 或 `download` 结尾的、在安装程序清单中的 URL 都视为安装程序 URL