### PR TITLE
[Auto] 自动忽略移除 - httpsdownloadesetcomcomesettoolsinstallersav_removerlatestavremover_arm64_enuexe

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -459,7 +459,6 @@ namespace checker
                 "https://aurorabuilder.com/downloads/Aurora%20Setup.zip", // 假400
                 "http://www.heaventools.com/files/11hFgnI0s/FlexHex_editor_setup.exe", // 讨论中 - https://github.com/microsoft/winget-pkgs/pull/251580
                 "https://cdn.localwp.com/releases-stable", // WIP - Flywheel.Local
-                "https://download.eset.com/com/eset/tools/installers/av_remover/latest/avremover_arm64_enu.exe", // WIP - https://github.com/microsoft/winget-pkgs/pull/250906
             ];
             return excludedDomains.Any(url.Contains);
         }


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `https://download.eset.com/com/eset/tools/installers/av_remover/latest/avremover_arm64_enu.exe`
理由: 修改已合并