### PR TITLE
[Auto] 自动忽略移除 - httpspbankbankcommcnpersonbankdownloadSecEditCFCAforBoComexe

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -463,7 +463,6 @@ namespace checker
                 "https://downloads.mysql.com/", "https://swcdn.apple.com/content/downloads/", "sourceforge.net", "https://static.centbrowser.cn/", "https://cdn1.waterfox.net/waterfox/releases/", "https://downloads.tableau.com/public/", "https://sp.thsi.cn/staticS3/mobileweb-upload-static-server.file/app_6/downloadcenter/THS_insoft", "https://files02.tchspt.com/down/", "https://cdn-dl.yinxiang.com/", "https://download.mono-project.com/archive/", "https://cdn-resource.aunbox.cn/", // 假403
                 "https://issuepcdn.baidupcs.com/", "https://lf-luna-release.qishui.com/obj/luna-release/", "https://down.360safe.com/cse/", // 超时
                 "https://www.argyllcms.com/", // 服务器拒绝冲泡咖啡
-                "https://pbank.bankcomm.cn/personbank/download/SecEditCFCAforBoCom.exe", // SSL错误
                 "https://aurorabuilder.com/downloads/Aurora%20Setup.zip", // 假400
                 "http://installer.jdownloader.org/JD2SilentSetup_x64.exe", // WIP - https://github.com/microsoft/winget-pkgs/pull/258347
             ];


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `https://pbank.bankcomm.cn/personbank/download/SecEditCFCAforBoCom.exe`
理由: 已忽略 SSL 连接错误