### PR TITLE
[Auto] 自动忽略移除 - httpinstallerjdownloaderorgJD2SilentSetup_x64exehttpinstallerjdownloaderorgJD2SilentSetup_x86exe

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -441,7 +441,6 @@ namespace checker
                 "https://issuepcdn.baidupcs.com/", "https://lf-luna-release.qishui.com/obj/luna-release/", "https://down.360safe.com/cse/", // 超时
                 "https://www.argyllcms.com/", // 服务器拒绝冲泡咖啡
                 "https://aurorabuilder.com/downloads/Aurora%20Setup.zip", // 假400
-                "http://installer.jdownloader.org/JD2SilentSetup_x64.exe", "http://installer.jdownloader.org/JD2SilentSetup_x86.exe", // WIP - https://github.com/microsoft/winget-pkgs/pull/258347
             ];
             return excludedDomains.Any(url.Contains);
         }


### PR DESCRIPTION
### 此 PR 由 [Sundry](https://github.com/DuckDuckStudio/Sundry/) 创建，用于向检查代码**移除**忽略字段 `http://installer.jdownloader.org/JD2SilentSetup_x64.exe", "http://installer.jdownloader.org/JD2SilentSetup_x86.exe`
理由: 已合并