### PR TITLE
fix(checker): 通过对意外类型检查的 URL 进行限制来防止 ReturnResponseUrl 被意外当成 InstallerUrl 进行检查

### DIFF
--- a/checker/Program.cs
+++ b/checker/Program.cs
@@ -298,7 +298,7 @@ namespace checker
             try
             {
                 HttpResponseMessage response = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, url));
-                if (((int)response.StatusCode >= 400) || !string.IsNullOrWhiteSpace(GetUnexpectedContentType(response.Content.Headers.ContentType?.MediaType ?? null)))
+                if (((int)response.StatusCode >= 400) || !string.IsNullOrWhiteSpace(GetUnexpectedContentType(url, response.Content.Headers.ContentType?.MediaType ?? null)))
                 {
                     response = await client.GetAsync(url);
                 }
@@ -460,7 +460,7 @@ namespace checker
                             // 忽略异常
                         }
                     }
-                    string? unexpectedType = GetUnexpectedContentType(response.Content.Headers.ContentType?.MediaType ?? null);
+                    string? unexpectedType = GetUnexpectedContentType(url, response.Content.Headers.ContentType?.MediaType ?? null);
                     if (!string.IsNullOrWhiteSpace(unexpectedType))
                     {
                         errorMessage = $"\n[Warning] <ManifestFilePath> 中的 {url} 响应的类型似乎不是有效的安装程序 ({unexpectedType})\n[Hint] Sundry 命令: sundry remove <PackageIdentifier> <PackageVersion> \"The installer url(s) responded with an unexpected type ({unexpectedType}) in GitHub Action.\"";
@@ -673,9 +673,9 @@ namespace checker
             return urls;
         }
 
-        static string? GetUnexpectedContentType(string? contentType)
+        static string? GetUnexpectedContentType(string url, string? contentType)
         {
-            if (!string.IsNullOrWhiteSpace(contentType))
+            if (!string.IsNullOrWhiteSpace(contentType) && installerType.Any(ext => url.EndsWith(ext, StringComparison.OrdinalIgnoreCase)))
             {
                 HashSet<string> unexpectedTypes = ["xml", "json", "html"];
                 if (unexpectedTypes.Any(i => contentType.Contains(i, StringComparison.OrdinalIgnoreCase)))


### PR DESCRIPTION
我知道这个限制写得很不好，我也知道我应该通过字段限制而不是 URL 末尾限制，我知道我应该重写 checker，但这太费时了。

这是个临时解决方案。